### PR TITLE
Fix LLM review line numbers

### DIFF
--- a/.github/scripts/parse_utils.py
+++ b/.github/scripts/parse_utils.py
@@ -30,9 +30,21 @@ def chunk_diff(
 
 
 def parse_review_chunk(content: str, chunk_start: int) -> List[Dict]:
-    """Parse LLM JSON output adjusting line numbers based on chunk start."""
+    """Parse LLM JSON output adjusting line numbers based on chunk start.
+
+    Raises ``ValueError`` if the parsed data is not in the expected format.
+    """
     data = json.loads(content)
+    if not isinstance(data, list):
+        raise ValueError("LLM output must be a JSON list")
+
     for comment in data:
-        if isinstance(comment.get("line"), int):
-            comment["line"] += chunk_start - 1
+        if not isinstance(comment, dict):
+            raise ValueError("Each review entry must be a JSON object")
+
+        if "line" not in comment or not isinstance(comment["line"], int):
+            raise ValueError("Review entry missing integer 'line' field")
+
+        comment["line"] += chunk_start - 1
+
     return data

--- a/.github/scripts/parse_utils.py
+++ b/.github/scripts/parse_utils.py
@@ -1,0 +1,38 @@
+import json
+from typing import Callable, List, Tuple, Dict
+
+
+def chunk_diff(
+    diff_text: str,
+    count_tokens: Callable[[str], int],
+    max_prompt_tokens: int,
+    base_tokens: int,
+) -> List[Tuple[str, int]]:
+    """Split a diff into token-safe chunks while tracking starting line numbers."""
+    lines = diff_text.splitlines(keepends=True)
+    chunks: List[Tuple[str, int]] = []
+    current: List[str] = []
+    tokens = base_tokens
+    current_start = 1
+    for i, line in enumerate(lines, 1):
+        lt = count_tokens(line)
+        if tokens + lt > max_prompt_tokens and current:
+            chunks.append(("".join(current), current_start))
+            current = [line]
+            current_start = i
+            tokens = base_tokens + lt
+        else:
+            current.append(line)
+            tokens += lt
+    if current:
+        chunks.append(("".join(current), current_start))
+    return chunks
+
+
+def parse_review_chunk(content: str, chunk_start: int) -> List[Dict]:
+    """Parse LLM JSON output adjusting line numbers based on chunk start."""
+    data = json.loads(content)
+    for comment in data:
+        if isinstance(comment.get("line"), int):
+            comment["line"] += chunk_start - 1
+    return data

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -91,7 +91,7 @@ for chunk_text, chunk_start in diff_chunks:
     try:
         chunk_data = parse_review_chunk(content, chunk_start)
         parsed.extend(chunk_data)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, ValueError) as e:
         print("❌ Failed to parse chunk JSON:", e)
         print("LLM Output:\n", content)
 

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -115,8 +115,7 @@ for entry in parsed:
         continue
     comments.append({
         "path": entry["file"],
-        "line": entry["line"],
-        "side": "RIGHT",
+        "position": entry["line"],
         "body": f"[{entry['domain'].capitalize()}] {entry['comment']}"
     })
 

--- a/tests/test_parse_utils.py
+++ b/tests/test_parse_utils.py
@@ -1,0 +1,26 @@
+import json
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '.github', 'scripts'))
+from parse_utils import chunk_diff, parse_review_chunk
+
+def simple_count(line: str) -> int:
+    return len(line)
+
+
+def test_chunk_diff_tracks_line_numbers():
+    diff_text = """line1\nline2\nline3\nline4\nline5\n"""
+    # max_prompt_tokens=20 to group roughly three lines using simple_count
+    chunks = chunk_diff(diff_text, simple_count, 20, 0)
+    assert chunks == [
+        ("line1\nline2\nline3\n", 1),
+        ("line4\nline5\n", 4)
+    ]
+
+
+def test_parse_review_chunk_offsets_lines():
+    content = json.dumps([
+        {"file": "a.py", "line": 2, "domain": "bug", "comment": "fix"}
+    ])
+    parsed = parse_review_chunk(content, 5)
+    assert parsed[0]["line"] == 6

--- a/tests/test_parse_utils.py
+++ b/tests/test_parse_utils.py
@@ -3,7 +3,7 @@ import os
 import sys
 import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '.github', 'scripts'))
-from parse_utils import chunk_diff, parse_review_chunk
+from parse_utils import chunk_diff, parse_review_chunk, diff_line_positions
 
 def simple_count(line: str) -> int:
     return len(line)
@@ -51,3 +51,20 @@ def test_parse_review_chunk_requires_line_int():
     content = json.dumps([{"file": "a.py", "line": "a", "domain": "bug", "comment": "x"}])
     with pytest.raises(ValueError):
         parse_review_chunk(content, 1)
+
+
+def test_diff_line_positions_maps_files_and_positions():
+    diff = (
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@\n"
+        "+added line\n"
+        " line1\n"
+        "@@\n"
+        " line2\n"
+    )
+    mapping = diff_line_positions(diff)
+    assert mapping[4] == ("a.py", 1)
+    assert mapping[5] == ("a.py", 2)
+    assert mapping[6] == ("a.py", 3)


### PR DESCRIPTION
## Summary
- adjust diff chunking to track starting line numbers
- offset review comments using each chunk's line offset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a727e32a4832ea9d101d3cefcce1f