### PR TITLE
Fix diff mapping for deleted lines

### DIFF
--- a/.github/scripts/parse_utils.py
+++ b/.github/scripts/parse_utils.py
@@ -86,6 +86,7 @@ def diff_line_positions(diff_text: str) -> Dict[int, Tuple[str, int]]:
 
         if current_file and in_hunk:
             position += 1
-            mapping[idx] = (current_file, position)
+            if not line.startswith("-"):
+                mapping[idx] = (current_file, position)
 
     return mapping

--- a/tests/test_parse_utils.py
+++ b/tests/test_parse_utils.py
@@ -80,3 +80,17 @@ def test_diff_line_positions_single_line_hunk():
     )
     mapping = diff_line_positions(diff)
     assert mapping[5] == ("b.py", 1)
+
+
+def test_diff_line_positions_skips_removed_lines():
+    diff = (
+        "diff --git a/c.py b/c.py\n"
+        "--- a/c.py\n"
+        "+++ b/c.py\n"
+        "@@\n"
+        "-old line\n"
+        "+new line\n"
+    )
+    mapping = diff_line_positions(diff)
+    assert 5 not in mapping
+    assert mapping[6] == ("c.py", 2)


### PR DESCRIPTION
## Summary
- avoid mapping deleted lines when calculating diff positions
- add regression test for removed lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a813802e8832e8e136ebd1c00b8e3